### PR TITLE
release: CLI v0.0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-cli"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,17 @@
-## [mcp-gateway] 0.0.5 - 2025-07-24
+## [CLI] 0.0.32 - 2025-07-24
 
 ### Changes
 
-- release: CLI v0.0.31 (#49)
 - release: Rust SDK v0.2.4 (#51)
 - release: Rust SDK v0.2.5 (#52)
 - release: Rust SDK v0.2.6 (#53)
 - release: Rust SDK v0.2.7 (#54)
 - release: TypeScript SDK v0.2.4 (#56)
+- release: mcp-gateway v0.0.5 (#57)
+- ✨ feat: Improve install.sh script. (#58)
 - 🐛 fix: exclude templates/examples from cargo update
+- 🐛 fix: install.sh interactive prompts
+- 🐛 fix: install.sh script
 - 🐛 fix: mcp-gateway rust sdk dep
 - 🐛 fix: rust sdk release
 - 🐛 fix: sdk release

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftl-cli"
-version = "0.0.31"
+version = "0.0.32"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## release: CLI v0.0.32

This PR prepares the release of **cli v0.0.32**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [CLI] 0.0.32 - 2025-07-24

### Changes

- release: Rust SDK v0.2.4 (#51)
- release: Rust SDK v0.2.5 (#52)
- release: Rust SDK v0.2.6 (#53)
- release: Rust SDK v0.2.7 (#54)
- release: TypeScript SDK v0.2.4 (#56)
- release: mcp-gateway v0.0.5 (#57)
- ✨ feat: Improve install.sh script. (#58)
- 🐛 fix: exclude templates/examples from cargo update
- 🐛 fix: install.sh interactive prompts
- 🐛 fix: install.sh script
- 🐛 fix: mcp-gateway rust sdk dep
- 🐛 fix: rust sdk release
- 🐛 fix: sdk release

### Contributors

- Ian McDonald
- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged