### PR TITLE
release: Rust SDK v0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-sdk"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "ftl-sdk-macros",
  "pretty_assertions",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-sdk-macros"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,15 @@
-## [mcp-gateway] 0.0.6 - 2025-07-24
+## [Rust SDK] 0.2.8 - 2025-07-24
 
 ### Changes
 
 - release: CLI v0.0.32 (#59)
+- release: mcp-gateway v0.0.5 (#57)
+- release: mcp-gateway v0.0.6 (#60)
+- ✨ feat: Improve install.sh script. (#58)
 - 🐛 fix: dup ci job
 - 🐛 fix: install.sh interactive prompts
 - 🐛 fix: install.sh script
+- 🔧 chore: update templates to ftl-sdk v0.2.7 (#55)
 
 ### Contributors
 

--- a/sdk/rust-macros/Cargo.toml
+++ b/sdk/rust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftl-sdk-macros"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftl-sdk"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 description = "Thin SDK providing MCP protocol types for FTL tool development"
 license.workspace = true
@@ -17,7 +17,7 @@ name = "ftl_sdk"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-ftl-sdk-macros = { version = "0.2.7", path = "../rust-macros", optional = true }
+ftl-sdk-macros = { version = "0.2.8", path = "../rust-macros", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
## release: Rust SDK v0.2.8

This PR prepares the release of **sdk-rust v0.2.8**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [Rust SDK] 0.2.8 - 2025-07-24

### Changes

- release: CLI v0.0.32 (#59)
- release: mcp-gateway v0.0.5 (#57)
- release: mcp-gateway v0.0.6 (#60)
- ✨ feat: Improve install.sh script. (#58)
- 🐛 fix: dup ci job
- 🐛 fix: install.sh interactive prompts
- 🐛 fix: install.sh script
- 🔧 chore: update templates to ftl-sdk v0.2.7 (#55)

### Contributors

- Ian McDonald
- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged