### PR TITLE
release: mcp-gateway v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-mcp-gateway"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "ftl-sdk",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,10 @@
-## [mcp-gateway] 0.0.7 - 2025-07-24
+## [mcp-gateway] 0.0.8 - 2025-07-24
 
 ### Changes
 
-- 🐛 fix: Check for wasm32-wasip1 in install.sh script
-- 🐛 fix: install.sh
-- 🐛 fix: install.sh don't install rust/wasm by default
-- 🐛 fix: prepare-release
-- 🐛 fix: spin install
-- 🔧 chore: update templates to ftl-sdk v0.2.8 (#62)
+- 🐛 fix: update templates on component release
+- 📚 docs: nit
 
 ### Contributors
 
-- Ian McDonald
 - bowlofarugula

--- a/components/mcp-gateway/Cargo.toml
+++ b/components/mcp-gateway/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ftl-mcp-gateway"
 authors.workspace = true
 description = "MCP gateway component"
-version = "0.0.7"
+version = "0.0.8"
 license.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/examples/demo/spin.toml
+++ b/examples/demo/spin.toml
@@ -89,7 +89,7 @@ route = { private = true }
 component = "ftl-mcp-gateway"
 
 [component.ftl-mcp-gateway]
-source = { registry = "ghcr.io", package = "fastertools:mcp-gateway", version = "0.0.7" }
+source = { registry = "ghcr.io", package = "fastertools:mcp-gateway", version = "0.0.8" }
 allowed_outbound_hosts = ["http://*.spin.internal"]
 [component.ftl-mcp-gateway.variables]
 tool_components = "{{ tool_components }}"

--- a/templates/ftl-mcp-server/content/spin.toml
+++ b/templates/ftl-mcp-server/content/spin.toml
@@ -89,7 +89,7 @@ route = { private = true }
 component = "ftl-mcp-gateway"
 
 [component.ftl-mcp-gateway]
-source = { registry = "ghcr.io", package = "fastertools:mcp-gateway", version = "0.0.3" }
+source = { registry = "ghcr.io", package = "fastertools:mcp-gateway", version = "0.0.8" }
 allowed_outbound_hosts = ["http://*.spin.internal"]
 [component.ftl-mcp-gateway.variables]
 tool_components = "{% raw %}{{ tool_components }}{% endraw %}"


### PR DESCRIPTION
## release: mcp-gateway v0.0.8

This PR prepares the release of **mcp-gateway v0.0.8**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [mcp-gateway] 0.0.8 - 2025-07-24

### Changes

- 🐛 fix: update templates on component release
- 📚 docs: nit

### Contributors

- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged