### PR TITLE
release: mcp-authorizer v0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-mcp-authorizer"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "base64",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,40 @@
-## [mcp-gateway] 0.0.8 - 2025-07-24
+## [mcp-authorizer] 0.0.9 - 2025-07-24
 
 ### Changes
 
+- release: CLI v0.0.31 (#49)
+- release: CLI v0.0.32 (#59)
+- release: Rust SDK v0.2.4 (#51)
+- release: Rust SDK v0.2.5 (#52)
+- release: Rust SDK v0.2.6 (#53)
+- release: Rust SDK v0.2.7 (#54)
+- release: Rust SDK v0.2.8 (#61)
+- release: TypeScript SDK v0.2.4 (#56)
+- release: mcp-gateway v0.0.5 (#57)
+- release: mcp-gateway v0.0.6 (#60)
+- release: mcp-gateway v0.0.7 (#63)
+- release: mcp-gateway v0.0.8 (#65)
+- ✨ feat: Improve install.sh script. (#58)
+- 🐛 fix: Check for wasm32-wasip1 in install.sh script
+- 🐛 fix: dup ci job
+- 🐛 fix: examples/demo ghcr.io refs
+- 🐛 fix: exclude templates/examples from cargo update
+- 🐛 fix: install.sh
+- 🐛 fix: install.sh don't install rust/wasm by default
+- 🐛 fix: install.sh interactive prompts
+- 🐛 fix: install.sh script
+- 🐛 fix: mcp-gateway rust sdk dep
+- 🐛 fix: prepare-release
+- 🐛 fix: rust sdk release
+- 🐛 fix: sdk release
+- 🐛 fix: spin install
 - 🐛 fix: update templates on component release
+- 📚 docs: install nit
 - 📚 docs: nit
+- 🔧 chore: update templates to ftl-sdk v0.2.7 (#55)
+- 🔧 chore: update templates to ftl-sdk v0.2.8 (#62)
 
 ### Contributors
 
+- Ian McDonald
 - bowlofarugula

--- a/components/mcp-authorizer/Cargo.toml
+++ b/components/mcp-authorizer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ftl-mcp-authorizer"
 authors.workspace = true
 description = "MCP authorization component for FTL servers using AuthKit"
-version = "0.0.8"
+version = "0.0.9"
 license.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/examples/demo/spin.toml
+++ b/examples/demo/spin.toml
@@ -67,7 +67,7 @@ route = "/.well-known/oauth-authorization-server"
 component = "mcp"
 
 [component.mcp]
-source = { registry = "ghcr.io", package = "fastertools:mcp-authorizer", version = "0.0.8" }
+source = { registry = "ghcr.io", package = "fastertools:mcp-authorizer", version = "0.0.9" }
 allowed_outbound_hosts = ["http://*.spin.internal", "https://*.authkit.app"]
 [component.mcp.variables]
 auth_enabled = "{{ auth_enabled }}"

--- a/templates/ftl-mcp-server/content/spin.toml
+++ b/templates/ftl-mcp-server/content/spin.toml
@@ -67,7 +67,7 @@ route = "/.well-known/oauth-authorization-server"
 component = "mcp"
 
 [component.mcp]
-source = { registry = "ghcr.io", package = "fastertools:mcp-authorizer", version = "0.0.6" }
+source = { registry = "ghcr.io", package = "fastertools:mcp-authorizer", version = "0.0.9" }
 allowed_outbound_hosts = ["http://*.spin.internal", "https://*.authkit.app"]
 [component.mcp.variables]
 auth_enabled = "{% raw %}{{ auth_enabled }}{% endraw %}"


### PR DESCRIPTION
## release: mcp-authorizer v0.0.9

This PR prepares the release of **mcp-authorizer v0.0.9**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [mcp-authorizer] 0.0.9 - 2025-07-24

### Changes

- release: CLI v0.0.31 (#49)
- release: CLI v0.0.32 (#59)
- release: Rust SDK v0.2.4 (#51)
- release: Rust SDK v0.2.5 (#52)
- release: Rust SDK v0.2.6 (#53)
- release: Rust SDK v0.2.7 (#54)
- release: Rust SDK v0.2.8 (#61)
- release: TypeScript SDK v0.2.4 (#56)
- release: mcp-gateway v0.0.5 (#57)
- release: mcp-gateway v0.0.6 (#60)
- release: mcp-gateway v0.0.7 (#63)
- release: mcp-gateway v0.0.8 (#65)
- ✨ feat: Improve install.sh script. (#58)
- 🐛 fix: Check for wasm32-wasip1 in install.sh script
- 🐛 fix: dup ci job
- 🐛 fix: examples/demo ghcr.io refs
- 🐛 fix: exclude templates/examples from cargo update
- 🐛 fix: install.sh
- 🐛 fix: install.sh don't install rust/wasm by default
- 🐛 fix: install.sh interactive prompts
- 🐛 fix: install.sh script
- 🐛 fix: mcp-gateway rust sdk dep
- 🐛 fix: prepare-release
- 🐛 fix: rust sdk release
- 🐛 fix: sdk release
- 🐛 fix: spin install
- 🐛 fix: update templates on component release
- 📚 docs: install nit
- 📚 docs: nit
- 🔧 chore: update templates to ftl-sdk v0.2.7 (#55)
- 🔧 chore: update templates to ftl-sdk v0.2.8 (#62)

### Contributors

- Ian McDonald
- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged