### PR TITLE
release: CLI v0.0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-cli"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,32 +1,17 @@
-## [mcp-authorizer] 0.0.9 - 2025-07-24
+## [CLI] 0.0.33 - 2025-07-24
 
 ### Changes
 
-- release: CLI v0.0.31 (#49)
-- release: CLI v0.0.32 (#59)
-- release: Rust SDK v0.2.4 (#51)
-- release: Rust SDK v0.2.5 (#52)
-- release: Rust SDK v0.2.6 (#53)
-- release: Rust SDK v0.2.7 (#54)
 - release: Rust SDK v0.2.8 (#61)
-- release: TypeScript SDK v0.2.4 (#56)
-- release: mcp-gateway v0.0.5 (#57)
+- release: mcp-authorizer v0.0.9 (#67)
 - release: mcp-gateway v0.0.6 (#60)
 - release: mcp-gateway v0.0.7 (#63)
 - release: mcp-gateway v0.0.8 (#65)
-- ✨ feat: Improve install.sh script. (#58)
 - 🐛 fix: Check for wasm32-wasip1 in install.sh script
-- 🐛 fix: dup ci job
-- 🐛 fix: examples/demo ghcr.io refs
-- 🐛 fix: exclude templates/examples from cargo update
 - 🐛 fix: install.sh
 - 🐛 fix: install.sh don't install rust/wasm by default
-- 🐛 fix: install.sh interactive prompts
-- 🐛 fix: install.sh script
-- 🐛 fix: mcp-gateway rust sdk dep
 - 🐛 fix: prepare-release
-- 🐛 fix: rust sdk release
-- 🐛 fix: sdk release
+- 🐛 fix: rm inaccurate message in add (#66)
 - 🐛 fix: spin install
 - 🐛 fix: update templates on component release
 - 📚 docs: install nit

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftl-cli"
-version = "0.0.32"
+version = "0.0.33"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## release: CLI v0.0.33

This PR prepares the release of **cli v0.0.33**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [CLI] 0.0.33 - 2025-07-24

### Changes

- release: Rust SDK v0.2.8 (#61)
- release: mcp-authorizer v0.0.9 (#67)
- release: mcp-gateway v0.0.6 (#60)
- release: mcp-gateway v0.0.7 (#63)
- release: mcp-gateway v0.0.8 (#65)
- 🐛 fix: Check for wasm32-wasip1 in install.sh script
- 🐛 fix: install.sh
- 🐛 fix: install.sh don't install rust/wasm by default
- 🐛 fix: prepare-release
- 🐛 fix: rm inaccurate message in add (#66)
- 🐛 fix: spin install
- 🐛 fix: update templates on component release
- 📚 docs: install nit
- 📚 docs: nit
- 🔧 chore: update templates to ftl-sdk v0.2.7 (#55)
- 🔧 chore: update templates to ftl-sdk v0.2.8 (#62)

### Contributors

- Ian McDonald
- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged