### PR TITLE
release: Rust SDK v0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-sdk"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "ftl-sdk-macros",
  "pretty_assertions",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-sdk-macros"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,13 @@
-## [CLI] 0.0.33 - 2025-07-24
+## [Rust SDK] 0.2.9 - 2025-07-25
 
 ### Changes
 
-- release: Rust SDK v0.2.8 (#61)
+- release: CLI v0.0.33 (#68)
 - release: mcp-authorizer v0.0.9 (#67)
-- release: mcp-gateway v0.0.6 (#60)
 - release: mcp-gateway v0.0.7 (#63)
 - release: mcp-gateway v0.0.8 (#65)
-- 🐛 fix: Check for wasm32-wasip1 in install.sh script
+- ✨ feat: Update SDKs to support multi-tool components (#69)
+- ✨ feat: Update mcp-gateway to support multi-tool components (#70)
 - 🐛 fix: install.sh
 - 🐛 fix: install.sh don't install rust/wasm by default
 - 🐛 fix: prepare-release
@@ -16,7 +16,6 @@
 - 🐛 fix: update templates on component release
 - 📚 docs: install nit
 - 📚 docs: nit
-- 🔧 chore: update templates to ftl-sdk v0.2.7 (#55)
 - 🔧 chore: update templates to ftl-sdk v0.2.8 (#62)
 
 ### Contributors

--- a/sdk/rust-macros/Cargo.toml
+++ b/sdk/rust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftl-sdk-macros"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftl-sdk"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 description = "Thin SDK providing MCP protocol types for FTL tool development"
 license.workspace = true
@@ -17,7 +17,7 @@ name = "ftl_sdk"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-ftl-sdk-macros = { version = "0.2.8", path = "../rust-macros", optional = true }
+ftl-sdk-macros = { version = "0.2.9", path = "../rust-macros", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
## release: Rust SDK v0.2.9

This PR prepares the release of **sdk-rust v0.2.9**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [Rust SDK] 0.2.9 - 2025-07-25

### Changes

- release: CLI v0.0.33 (#68)
- release: mcp-authorizer v0.0.9 (#67)
- release: mcp-gateway v0.0.7 (#63)
- release: mcp-gateway v0.0.8 (#65)
- ✨ feat: Update SDKs to support multi-tool components (#69)
- ✨ feat: Update mcp-gateway to support multi-tool components (#70)
- 🐛 fix: install.sh
- 🐛 fix: install.sh don't install rust/wasm by default
- 🐛 fix: prepare-release
- 🐛 fix: rm inaccurate message in add (#66)
- 🐛 fix: spin install
- 🐛 fix: update templates on component release
- 📚 docs: install nit
- 📚 docs: nit
- 🔧 chore: update templates to ftl-sdk v0.2.8 (#62)

### Contributors

- Ian McDonald
- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged