### PR TITLE
release: TypeScript SDK v0.2.5

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,23 @@
-## [CLI] 0.0.33 - 2025-07-24
+## [TypeScript SDK] 0.2.5 - 2025-07-25
 
 ### Changes
 
+- release: CLI v0.0.32 (#59)
+- release: CLI v0.0.33 (#68)
 - release: Rust SDK v0.2.8 (#61)
 - release: mcp-authorizer v0.0.9 (#67)
 - release: mcp-gateway v0.0.6 (#60)
 - release: mcp-gateway v0.0.7 (#63)
 - release: mcp-gateway v0.0.8 (#65)
+- ✨ feat: Improve install.sh script. (#58)
+- ✨ feat: Update SDKs to support multi-tool components (#69)
+- ✨ feat: Update mcp-gateway to support multi-tool components (#70)
 - 🐛 fix: Check for wasm32-wasip1 in install.sh script
+- 🐛 fix: dup ci job
 - 🐛 fix: install.sh
 - 🐛 fix: install.sh don't install rust/wasm by default
+- 🐛 fix: install.sh interactive prompts
+- 🐛 fix: install.sh script
 - 🐛 fix: prepare-release
 - 🐛 fix: rm inaccurate message in add (#66)
 - 🐛 fix: spin install

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ftl-sdk",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ftl-sdk",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftl-sdk",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Thin SDK providing MCP protocol types for FTL tool development",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## release: TypeScript SDK v0.2.5

This PR prepares the release of **sdk-typescript v0.2.5**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [TypeScript SDK] 0.2.5 - 2025-07-25

### Changes

- release: CLI v0.0.32 (#59)
- release: CLI v0.0.33 (#68)
- release: Rust SDK v0.2.8 (#61)
- release: mcp-authorizer v0.0.9 (#67)
- release: mcp-gateway v0.0.6 (#60)
- release: mcp-gateway v0.0.7 (#63)
- release: mcp-gateway v0.0.8 (#65)
- ✨ feat: Improve install.sh script. (#58)
- ✨ feat: Update SDKs to support multi-tool components (#69)
- ✨ feat: Update mcp-gateway to support multi-tool components (#70)
- 🐛 fix: Check for wasm32-wasip1 in install.sh script
- 🐛 fix: dup ci job
- 🐛 fix: install.sh
- 🐛 fix: install.sh don't install rust/wasm by default
- 🐛 fix: install.sh interactive prompts
- 🐛 fix: install.sh script
- 🐛 fix: prepare-release
- 🐛 fix: rm inaccurate message in add (#66)
- 🐛 fix: spin install
- 🐛 fix: update templates on component release
- 📚 docs: install nit
- 📚 docs: nit
- 🔧 chore: update templates to ftl-sdk v0.2.7 (#55)
- 🔧 chore: update templates to ftl-sdk v0.2.8 (#62)

### Contributors

- Ian McDonald
- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged