### PR TITLE
release: mcp-gateway v0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-mcp-gateway"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "ftl-sdk",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,25 +1,12 @@
-## [CLI] 0.0.33 - 2025-07-24
+## [mcp-gateway] 0.0.9 - 2025-07-25
 
 ### Changes
 
-- release: Rust SDK v0.2.8 (#61)
-- release: mcp-authorizer v0.0.9 (#67)
-- release: mcp-gateway v0.0.6 (#60)
-- release: mcp-gateway v0.0.7 (#63)
-- release: mcp-gateway v0.0.8 (#65)
-- 🐛 fix: Check for wasm32-wasip1 in install.sh script
-- 🐛 fix: install.sh
-- 🐛 fix: install.sh don't install rust/wasm by default
-- 🐛 fix: prepare-release
+- release: CLI v0.0.33 (#68)
+- ✨ feat: Update SDKs to support multi-tool components (#69)
+- ✨ feat: Update mcp-gateway to support multi-tool components (#70)
 - 🐛 fix: rm inaccurate message in add (#66)
-- 🐛 fix: spin install
-- 🐛 fix: update templates on component release
-- 📚 docs: install nit
-- 📚 docs: nit
-- 🔧 chore: update templates to ftl-sdk v0.2.7 (#55)
-- 🔧 chore: update templates to ftl-sdk v0.2.8 (#62)
 
 ### Contributors
 
 - Ian McDonald
-- bowlofarugula

--- a/components/mcp-gateway/Cargo.toml
+++ b/components/mcp-gateway/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ftl-mcp-gateway"
 authors.workspace = true
 description = "MCP gateway component"
-version = "0.0.8"
+version = "0.0.9"
 license.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/examples/demo/spin.toml
+++ b/examples/demo/spin.toml
@@ -89,7 +89,7 @@ route = { private = true }
 component = "ftl-mcp-gateway"
 
 [component.ftl-mcp-gateway]
-source = { registry = "ghcr.io", package = "fastertools:mcp-gateway", version = "0.0.8" }
+source = { registry = "ghcr.io", package = "fastertools:mcp-gateway", version = "0.0.9" }
 allowed_outbound_hosts = ["http://*.spin.internal"]
 [component.ftl-mcp-gateway.variables]
 tool_components = "{{ tool_components }}"

--- a/templates/ftl-mcp-server/content/spin.toml
+++ b/templates/ftl-mcp-server/content/spin.toml
@@ -89,7 +89,7 @@ route = { private = true }
 component = "ftl-mcp-gateway"
 
 [component.ftl-mcp-gateway]
-source = { registry = "ghcr.io", package = "fastertools:mcp-gateway", version = "0.0.8" }
+source = { registry = "ghcr.io", package = "fastertools:mcp-gateway", version = "0.0.9" }
 allowed_outbound_hosts = ["http://*.spin.internal"]
 [component.ftl-mcp-gateway.variables]
 tool_components = "{% raw %}{{ tool_components }}{% endraw %}"


### PR DESCRIPTION
## release: mcp-gateway v0.0.9

This PR prepares the release of **mcp-gateway v0.0.9**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [mcp-gateway] 0.0.9 - 2025-07-25

### Changes

- release: CLI v0.0.33 (#68)
- ✨ feat: Update SDKs to support multi-tool components (#69)
- ✨ feat: Update mcp-gateway to support multi-tool components (#70)
- 🐛 fix: rm inaccurate message in add (#66)

### Contributors

- Ian McDonald

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged