### PR TITLE
release: Rust SDK v0.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-sdk"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "ftl-sdk-macros",
  "pretty_assertions",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-sdk-macros"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,16 +1,19 @@
-## [CLI] 0.0.34 - 2025-07-25
+## [Rust SDK] 0.2.10 - 2025-07-25
 
 ### Changes
 
-- release: Rust SDK v0.2.9 (#74)
-- release: TypeScript SDK v0.2.5 (#72)
+- release: CLI v0.0.34 (#80)
 - release: mcp-gateway v0.0.9 (#75)
-- ✨ feat: Update mcp-gateway to support multi-tool components (#70)
 - ✨ feat: Update templates and examples (#79)
 - 🐛 fix: Don't run cli tests for Cargo.toml/lock changes (#78)
+- 🐛 fix: Housekeeping (#82)
+- 🐛 fix: Housekeeping and ts sdk issue (#83)
 - 🐛 fix: checkrun selection in CI (#77)
-- 🔧 chore: update templates to ftl-sdk v0.2.9 (#76)
+- 🐛 fix: config etc. (#81)
+- 🐛 fix: ftl add templates
+- 🐛 fix: templates camel_case filter
 
 ### Contributors
 
 - Ian McDonald
+- bowlofarugula

--- a/sdk/rust-macros/Cargo.toml
+++ b/sdk/rust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftl-sdk-macros"
-version = "0.2.9"
+version = "0.2.10"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftl-sdk"
-version = "0.2.9"
+version = "0.2.10"
 edition.workspace = true
 description = "Thin SDK providing MCP protocol types for FTL tool development"
 license.workspace = true
@@ -17,7 +17,7 @@ name = "ftl_sdk"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-ftl-sdk-macros = { version = "0.2.9", path = "../rust-macros", optional = true }
+ftl-sdk-macros = { version = "0.2.10", path = "../rust-macros", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
## release: Rust SDK v0.2.10

This PR prepares the release of **sdk-rust v0.2.10**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [Rust SDK] 0.2.10 - 2025-07-25

### Changes

- release: CLI v0.0.34 (#80)
- release: mcp-gateway v0.0.9 (#75)
- ✨ feat: Update templates and examples (#79)
- 🐛 fix: Don't run cli tests for Cargo.toml/lock changes (#78)
- 🐛 fix: Housekeeping (#82)
- 🐛 fix: Housekeeping and ts sdk issue (#83)
- 🐛 fix: checkrun selection in CI (#77)
- 🐛 fix: config etc. (#81)
- 🐛 fix: ftl add templates
- 🐛 fix: templates camel_case filter

### Contributors

- Ian McDonald
- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged