### PR TITLE
release: TypeScript SDK v0.2.6

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,9 @@
-## [Rust SDK] 0.2.10 - 2025-07-25
+## [TypeScript SDK] 0.2.6 - 2025-07-25
 
 ### Changes
 
 - release: CLI v0.0.34 (#80)
+- release: Rust SDK v0.2.10 (#84)
 - release: mcp-gateway v0.0.9 (#75)
 - ✨ feat: Update templates and examples (#79)
 - 🐛 fix: Don't run cli tests for Cargo.toml/lock changes (#78)
@@ -12,6 +13,7 @@
 - 🐛 fix: config etc. (#81)
 - 🐛 fix: ftl add templates
 - 🐛 fix: templates camel_case filter
+- 🔧 chore: update templates to ftl-sdk v0.2.9 (#76)
 
 ### Contributors
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ftl-sdk",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ftl-sdk",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftl-sdk",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Thin SDK providing MCP protocol types for FTL tool development",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## release: TypeScript SDK v0.2.6

This PR prepares the release of **sdk-typescript v0.2.6**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [TypeScript SDK] 0.2.6 - 2025-07-25

### Changes

- release: CLI v0.0.34 (#80)
- release: Rust SDK v0.2.10 (#84)
- release: mcp-gateway v0.0.9 (#75)
- ✨ feat: Update templates and examples (#79)
- 🐛 fix: Don't run cli tests for Cargo.toml/lock changes (#78)
- 🐛 fix: Housekeeping (#82)
- 🐛 fix: Housekeeping and ts sdk issue (#83)
- 🐛 fix: checkrun selection in CI (#77)
- 🐛 fix: config etc. (#81)
- 🐛 fix: ftl add templates
- 🐛 fix: templates camel_case filter
- 🔧 chore: update templates to ftl-sdk v0.2.9 (#76)

### Contributors

- Ian McDonald
- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged