### PR TITLE
release: CLI v0.0.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "ftl-cli"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,23 @@
-## [TypeScript SDK] 0.2.7 - 2025-07-25
+## [CLI] 0.0.35 - 2025-07-28
 
 ### Changes
 
+- nit: README
+- release: Rust SDK v0.2.10 (#84)
+- release: TypeScript SDK v0.2.6 (#86)
+- release: TypeScript SDK v0.2.7 (#88)
+- ✨ feat: Add Tools and Registry commands (#93)
+- ✨ feat: Use new backend API (#94)
+- 🐛 fix: Housekeeping and ts sdk issue (#83)
+- 🐛 fix: TS examples deps (#90)
 - 🐛 fix: TS sdk types (#87)
+- 🐛 fix: Templates (#89)
+- 🐛 fix: nits, lockfiles (#91)
 - 📚 docs: fix diagram
+- 🔧 chore: update templates to ftl-sdk v0.2.10 (#85)
 
 ### Contributors
 
+- Corey Ryan
 - Ian McDonald
 - bowlofarugula

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftl-cli"
-version = "0.0.34"
+version = "0.0.35"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## release: CLI v0.0.35

This PR prepares the release of **cli v0.0.35**.

### 📋 Checklist

- [ ] Version bumped correctly
- [ ] Changelog updated
- [ ] All tests passing
- [ ] Documentation updated if needed

### 📝 Release Notes

## [CLI] 0.0.35 - 2025-07-28

### Changes

- nit: README
- release: Rust SDK v0.2.10 (#84)
- release: TypeScript SDK v0.2.6 (#86)
- release: TypeScript SDK v0.2.7 (#88)
- ✨ feat: Add Tools and Registry commands (#93)
- ✨ feat: Use new backend API (#94)
- 🐛 fix: Housekeeping and ts sdk issue (#83)
- 🐛 fix: TS examples deps (#90)
- 🐛 fix: TS sdk types (#87)
- 🐛 fix: Templates (#89)
- 🐛 fix: nits, lockfiles (#91)
- 📚 docs: fix diagram
- 🔧 chore: update templates to ftl-sdk v0.2.10 (#85)

### Contributors

- Corey Ryan
- Ian McDonald
- bowlofarugula

### 🔄 Release Process

1. Review and merge this PR
2. The release will be tagged automatically
3. The release workflow will then:
   - Build and publish artifacts
   - Create GitHub release
   - Publish to package registries

### ⚠️ Important

- Ensure all CI checks pass before merging
- Review the changelog for accuracy
- Verify version numbers are correct
- **DO NOT** manually create the tag - it will be created automatically when merged