### PR TITLE
fix: Update Go SDK version in README during release prep

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -208,9 +208,8 @@ jobs:
                 sed -i "s/^Version: .*/Version: ${NEW_VERSION}/" sdk/go/README.md
               else
                 # Add version line after the title if it doesn't exist
-                sed -i "2a\\
-Version: ${NEW_VERSION}\\
-" sdk/go/README.md
+                # Using a more YAML-friendly approach
+                awk 'NR==2 {print; print "Version: '"${NEW_VERSION}"'\n"} NR!=2' sdk/go/README.md > sdk/go/README.md.tmp && mv sdk/go/README.md.tmp sdk/go/README.md
               fi
               
               # Run go mod tidy to ensure module is clean


### PR DESCRIPTION
## Summary

This PR fixes an issue where the prepare-release workflow for Go SDKs had nothing to commit, causing the workflow to fail.

## Problem

Go modules use git tags for versioning rather than version files, so when the prepare-release workflow runs for , it has no file changes to commit, resulting in an error:


## Solution

Update the Go SDK README.md with a version line during release preparation. This ensures:
1. There are actual file changes to commit in the release PR
2. The version is documented in the README for clarity
3. The workflow can complete successfully

## Changes

- Modified the  case in prepare-release.yml to:
  - Add or update a  line in the README.md
  - Place it after the title if it doesn't exist
  - Update it if it already exists

## Testing

This will be tested when the next Go SDK release is prepared. The workflow will now have file changes to commit and should complete successfully.