### PR TITLE
fix: Fix Go SDK release tagging and add module subdirectory support

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -42,6 +42,12 @@ jobs:
               "TypeScript SDK")
                 TAG="sdk-typescript-v${VERSION}"
                 ;;
+              "Python SDK")
+                TAG="sdk-python-v${VERSION}"
+                ;;
+              "Go SDK")
+                TAG="sdk-go-v${VERSION}"
+                ;;
               *)
                 # Assume it's a component name
                 COMPONENT_LOWER=$(echo "$COMPONENT" | tr '[:upper:]' '[:lower:]')
@@ -80,6 +86,18 @@ jobs:
           
           # Push tag
           git push origin "$TAG"
+          
+          # For Go SDK, also create the Go module subdirectory tag
+          if [[ "$COMPONENT" == "Go SDK" ]]; then
+            GO_MODULE_TAG="sdk/go/v$VERSION"
+            git tag -a "$GO_MODULE_TAG" -m "Release $COMPONENT v$VERSION
+
+          Automated release from PR #${{ github.event.pull_request.number }}
+          
+          ${{ github.event.pull_request.body }}"
+            git push origin "$GO_MODULE_TAG"
+            echo "✅ Also created Go module tag: $GO_MODULE_TAG"
+          fi
           
           echo "✅ Created and pushed tag: $TAG"
           echo "The release workflow will now be triggered automatically!"

--- a/.github/workflows/release-sdk-go.yml
+++ b/.github/workflows/release-sdk-go.yml
@@ -155,9 +155,14 @@ jobs:
         tag_name="sdk-go-v${{ inputs.version }}"
         git tag -a "$tag_name" -m "Release Go SDK v${{ inputs.version }}"
         
-        # Push the commit and tag
+        # Also create Go module subdirectory tag for proper Go module versioning
+        go_module_tag="sdk/go/v${{ inputs.version }}"
+        git tag -a "$go_module_tag" -m "Release Go SDK v${{ inputs.version }}"
+        
+        # Push the commit and tags
         git push origin HEAD:main
         git push origin "$tag_name"
+        git push origin "$go_module_tag"
 
     - name: Generate release notes
       id: release_notes
@@ -211,3 +216,11 @@ jobs:
         else
           echo "⚠️  Module may take a few minutes to appear in the proxy"
         fi
+        
+        echo ""
+        echo "📦 Go module users can import with:"
+        echo "  go get github.com/fastertools/ftl-cli/sdk/go@v${{ inputs.version }}"
+        echo ""
+        echo "🏷️  Created tags:"
+        echo "  - sdk-go-v${{ inputs.version }} (release tracking)"
+        echo "  - sdk/go/v${{ inputs.version }} (Go module resolution)"


### PR DESCRIPTION
## Summary

This PR fixes the Go SDK release tagging issue that was causing `fatal: 'component-go sdk-v0.1.0' is not a valid tag name` error.

## Problem

The `auto-tag-release.yml` workflow wasn't handling "Go SDK" releases properly, causing it to fall through to the component case and create invalid tags with spaces.

## Solution

1. **Fixed invalid tag names**: Added explicit cases for "Python SDK" and "Go SDK" in `auto-tag-release.yml` to ensure proper tag formatting
2. **Added Go module subdirectory tagging**: Following Go module conventions for monorepos, the workflows now create two tags for Go SDK releases:
   - `sdk-go-vX.Y.Z` - for consistency with other SDKs  
   - `sdk/go/vX.Y.Z` - for proper Go module resolution

## Changes

- Updated `.github/workflows/auto-tag-release.yml` to handle SDK cases properly
- Updated `.github/workflows/release-sdk-go.yml` to create both tag formats
- Added verification output to show both tags created

## Testing

After this change, Go SDK releases will:
1. Create valid tags without spaces
2. Allow Go developers to import the module using standard tooling:
   ```bash
   go get github.com/fastertools/ftl-cli/sdk/go@v0.1.0
   ```

## Related Issues

Fixes the release workflow error seen when trying to tag Go SDK v0.1.0.