### PR TITLE
chore((main)): release  component-mcp-authorizer v0.10.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,5 +6,5 @@
   "sdk/python": "0.10.0",
   "sdk/typescript": "0.10.0",
   "components/mcp-gateway": "0.10.0",
-  "components/mcp-authorizer": "0.10.0"
+  "components/mcp-authorizer": "0.10.1"
 }

--- a/components/mcp-authorizer/Cargo.toml
+++ b/components/mcp-authorizer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mcp-authorizer"
 authors.workspace = true
 description = "MCP authorization component for FTL servers using AuthKit"
-version = "0.1.0"
+version = "0.10.1"
 license.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/components/mcp-authorizer/components/mcp-authorizer/CHANGELOG.md
+++ b/components/mcp-authorizer/components/mcp-authorizer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.10.1 (2025-08-22)
+
+**Full Changelog**: https://github.com/fastertools/ftl/compare/component-mcp-authorizer-v0.10.0...component-mcp-authorizer-v0.10.1


### PR DESCRIPTION
:rocket: Release PR

This PR was generated by [release-please](https://github.com/googleapis/release-please).
---


## 0.10.1 (2025-08-22)

**Full Changelog**: https://github.com/fastertools/ftl/compare/component-mcp-authorizer-v0.10.0...component-mcp-authorizer-v0.10.1

---

---

:warning: **Do not manually edit this PR**. Any manual changes will be overwritten by release-please.

To make changes, commit to `main` with conventional commit messages.