### PR TITLE
chore((main)): release  component-mcp-gateway v0.10.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,6 +5,6 @@
   "sdk/rust": "0.10.0",
   "sdk/python": "0.10.0",
   "sdk/typescript": "0.10.0",
-  "components/mcp-gateway": "0.10.0",
+  "components/mcp-gateway": "0.10.1",
   "components/mcp-authorizer": "0.10.0"
 }

--- a/components/mcp-gateway/Cargo.toml
+++ b/components/mcp-gateway/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mcp-gateway"
 authors.workspace = true
 description = "MCP gateway component"
-version = "0.1.0"
+version = "0.10.1"
 license.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/components/mcp-gateway/components/mcp-gateway/CHANGELOG.md
+++ b/components/mcp-gateway/components/mcp-gateway/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.10.1 (2025-08-22)
+
+**Full Changelog**: https://github.com/fastertools/ftl/compare/component-mcp-gateway-v0.10.0...component-mcp-gateway-v0.10.1


### PR DESCRIPTION
:rocket: Release PR

This PR was generated by [release-please](https://github.com/googleapis/release-please).
---


## 0.10.1 (2025-08-22)

**Full Changelog**: https://github.com/fastertools/ftl/compare/component-mcp-gateway-v0.10.0...component-mcp-gateway-v0.10.1

---

---

:warning: **Do not manually edit this PR**. Any manual changes will be overwritten by release-please.

To make changes, commit to `main` with conventional commit messages.