### PR TITLE
chore((main)): release  sdk-typescript v0.10.1

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ftl-sdk",
-  "version": "0.2.8",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ftl-sdk",
-      "version": "0.2.8",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ftl-sdk",
-  "version": "0.3.0",
+  "version": "0.10.1",
   "description": "Thin SDK providing MCP protocol types for FTL tool development",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/typescript/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/sdk/typescript/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.10.1 (2025-08-22)
+
+**Full Changelog**: https://github.com/fastertools/ftl/compare/sdk-typescript-v0.10.0...sdk-typescript-v0.10.1


### PR DESCRIPTION
:rocket: Release PR

This PR was generated by [release-please](https://github.com/googleapis/release-please).
---


## 0.10.1 (2025-08-22)

**Full Changelog**: https://github.com/fastertools/ftl/compare/sdk-typescript-v0.10.0...sdk-typescript-v0.10.1

---

---

:warning: **Do not manually edit this PR**. Any manual changes will be overwritten by release-please.

To make changes, commit to `main` with conventional commit messages.