### PR TITLE
test: verify selective CI for Rust SDK changes

### DIFF
--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -1,5 +1,6 @@
 # ftl-sdk (Rust)
 
+<!-- Testing selective CI implementation -->
 Rust SDK for building Model Context Protocol (MCP) tools on WebAssembly.
 
 [Documentation](https://docs.rs/ftl-sdk) | [Examples](https://github.com/fastertools/ftl/tree/main/templates/rust)


### PR DESCRIPTION
Testing that selective CI only runs Rust SDK tests when only Rust SDK files change.